### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/common_pitfalls.md
+++ b/docs/common_pitfalls.md
@@ -99,7 +99,7 @@ The following table highlights the differences between objects and non-objects:
 :                       :                         : attribute)               :
 | Allow mixed type in a | No                      | Yes                      |
 : DataSlice             :                         :                          :
-| Where schema(s) are   | DataSlice level         | Level of Iindividual     |
+| Where schema(s) are   | DataSlice level         | Level of Individual      |
 : stored                :                         : items (as `__schema__`   :
 :                       :                         : attribute or inferred    :
 :                       :                         : from primitive data)     :

--- a/docs/fundamentals.md
+++ b/docs/fundamentals.md
@@ -2,7 +2,7 @@
 
 # Koda Fundamentals
 
-This guide goes through fundemantals in Koda. It is highly recommended to read
+This guide goes through fundamentals in Koda. It is highly recommended to read
 through the guide in order for new users to use Koda effectively.
 
 Also see [Koda Cheatsheet](cheatsheet.md) for quick references and


### PR DESCRIPTION
## Summary

This PR fixes typos found in the documentation files.

## Changes

| File | Line | Typo | Fix |
|------|------|------|-----|
| `docs/fundamentals.md` | 5 | fundemantals | fundamentals |
| `docs/common_pitfalls.md` | 102 | Iindividual | Individual |

## Testing

No code changes - documentation only.