### PR TITLE
docs: fix typos in comments and error messages

### DIFF
--- a/docs/api/kd/functor.md
+++ b/docs/api/kd/functor.md
@@ -182,7 +182,7 @@ Returns:
 <pre class="no-copy"><code class="lang-text no-auto-prettify">Special call that will be transformed to expect fn to return a stream.
 
 It should be used only if functor is provided externally in production
-enviroment. Prefer `functor.call` for functors fully implemented in Python.
+environment. Prefer `functor.call` for functors fully implemented in Python.
 
 Args:
   fn: function to be called. Should return Iterable in interactive mode and

--- a/koladata/internal/data_bag.cc
+++ b/koladata/internal/data_bag.cc
@@ -360,7 +360,7 @@ absl::Status MergeToMutableDenseSource(
       auto other_items,
       GetAttributeFromSources(objects, {&dense_source}, sparse_sources));
   // GetAttributeFromSources returns information about unset values in
-  // TypesBuffer withing DataSliceImpl. Ensure that TypesBuffer is there.
+  // TypesBuffer within DataSliceImpl. Ensure that TypesBuffer is there.
   DCHECK_GT(size, 0);
   DCHECK(!other_items.types_buffer().id_to_typeidx.empty());
 

--- a/koladata/internal/op_utils/group_by_utils.h
+++ b/koladata/internal/op_utils/group_by_utils.h
@@ -81,7 +81,7 @@ class ObjectsGroupBy {
       const arolla::DenseArray<ObjectId>& objs) {
     ASSIGN_OR_RETURN(auto group_sizes,
                      arolla::DenseArrayEdgeSizesOp()(&ctx_, edge));
-    ASSIGN_OR_RETURN(auto indicies, agg_index_op_.Apply(edge, objs.ToMask()));
+    ASSIGN_OR_RETURN(auto indices, agg_index_op_.Apply(edge, objs.ToMask()));
     std::vector<arolla::DenseArrayBuilder<ObjectId>> objs_grouped_bldr;
     objs_grouped_bldr.reserve(group_sizes.size());
     group_sizes.ForEachPresent([&](int64_t idx, int64_t size) {
@@ -91,7 +91,7 @@ class ObjectsGroupBy {
         [&](size_t idx, ObjectId new_obj, int64_t group_id, int64_t index) {
           objs_grouped_bldr[group_id].Set(index - 1, new_obj);
         },
-        objs, edge.ToMappingEdge().edge_values(), indicies));
+        objs, edge.ToMappingEdge().edge_values(), indices));
     std::vector<arolla::DenseArray<ObjectId>> objs_grouped;
     objs_grouped.reserve(group_sizes.size());
     for (auto& bldr : objs_grouped_bldr) {

--- a/koladata/operators/slices.cc
+++ b/koladata/operators/slices.cc
@@ -168,7 +168,7 @@ absl::StatusOr<DataSlice> ConcatOrStackImpl(bool stack, int64_t ndim,
   if (!stack) {  // concat
     if (rank == 0) {
       return absl::InvalidArgumentError(
-          "concatentation of DataItems (rank=0) is not supported - use stack "
+          "concatenation of DataItems (rank=0) is not supported - use stack "
           "instead");
     } else if (ndim < 1 || ndim > rank) {
       return absl::InvalidArgumentError(

--- a/py/koladata/ext/storage/schema_helper.py
+++ b/py/koladata/ext/storage/schema_helper.py
@@ -712,7 +712,7 @@ class SchemaHelper:
     Which schema node names of updated_ds.get_schema() could be affected by this
     update? A schema node name is affected if the update can provide it with new
     data. So schema node names that are newly introduced are affected, as are
-    existing schema node names for which the update can provide new/overriden
+    existing schema node names for which the update can provide new/overridden
     data.
 
     Important to note:

--- a/py/koladata/operators/functor.py
+++ b/py/koladata/operators/functor.py
@@ -160,7 +160,7 @@ def call_fn_returning_stream_when_parallel(
   """Special call that will be transformed to expect fn to return a stream.
 
   It should be used only if functor is provided externally in production
-  enviroment. Prefer `functor.call` for functors fully implemented in Python.
+  environment. Prefer `functor.call` for functors fully implemented in Python.
 
   Args:
     fn: function to be called. Should return Iterable in interactive mode and

--- a/py/koladata/operators/tests/slices_concat_test.py
+++ b/py/koladata/operators/tests/slices_concat_test.py
@@ -160,7 +160,7 @@ class SlicesConcatImplTest(parameterized.TestCase):
           ),
           0,
           (
-              'concatentation of DataItems (rank=0) is not supported - use'
+              'concatenation of DataItems (rank=0) is not supported - use'
               ' stack instead'
           ),
       ),


### PR DESCRIPTION
Seven spelling fixes across seven files — comments, docstrings, and error messages:

- `docs/api/kd/functor.md` + `py/koladata/operators/functor.py`: `enviroment` → `environment`
- `koladata/operators/slices.cc` + matching test: `concatentation` → `concatenation`
- `koladata/internal/data_bag.cc`: `withing` → `within`
- `py/koladata/ext/storage/schema_helper.py`: `overriden` → `overridden`
- `koladata/internal/op_utils/group_by_utils.h`: `indicies` → `indices` (local variable rename, no API change)